### PR TITLE
CLI Windows Support

### DIFF
--- a/kales-cli/src/main/kotlin/kales/cli/task/NewApplicationTask.kt
+++ b/kales-cli/src/main/kotlin/kales/cli/task/NewApplicationTask.kt
@@ -74,9 +74,13 @@ class NewApplicationTask(
 
   private fun Path.makeExecutable() {
     if (!exists(this)) {
-      val ownerWritable = PosixFilePermissions.fromString("rwxr--r--")
-      val permissions = PosixFilePermissions.asFileAttribute(ownerWritable)
-      Files.createFile(this, permissions)
+      if(System.getProperty("os.name","").toLowerCase().indexOf("win") >= 0){
+        Files.createFile(this)  
+      }else{
+        val ownerWritable = PosixFilePermissions.fromString("rwxr--r--")
+        val permissions = PosixFilePermissions.asFileAttribute(ownerWritable)
+        Files.createFile(this, permissions)
+      }
     }
   }
 

--- a/scripts/kales.bat
+++ b/scripts/kales.bat
@@ -1,0 +1,84 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  kales cli script for Windows
+@rem
+@rem  heavily based on gradle batch file
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS to pass JVM options to this script.
+@rem set DEFAULT_JVM_OPTS=-agentlib:jdwp=transport=dt_socket,address=7000,server=y,suspend=n
+set DEFAULT_JVM_OPTS=
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+@rem Execute machine.integration
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% -jar %APP_HOME%\kales-cli.jar %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable KALES_CLI_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%KALES_CLI_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega


### PR DESCRIPTION
Hi Felipe,

**Few Points to consider:**

1. Windows New application task issue: Posix Permissions (fixed)
2. New kales.bat file added (actually not required IMHO, because of gradle application plugin generated distribution) ```gradle build``` or ```gradle distZip``` or ```gradle distTar```
3. Even for other Operating systems, gradle generated distributions (.zip/.tar inside build/distributions) are enough IMHO (see first image below)
4. I have used gradle generated distribution in my system (see the second image)
5. ```gradle run``` on newly created app fails (may be due to missing route handler for URL http://0.0.0.0:8080/)
6. kales-cli tests are failing in windows (yet to be fixed)

Share your thoughts on this to take it further.

![image](https://user-images.githubusercontent.com/1082966/60764520-33c55b80-a0a9-11e9-8c8f-a818041a7d25.png)

![image](https://user-images.githubusercontent.com/1082966/60764710-49885000-a0ac-11e9-8d15-87e54f1ae08f.png)

> gradle run (failed may be due to missing route handler for URL http://0.0.0.0:8080/)

![image](https://user-images.githubusercontent.com/1082966/60764725-7e94a280-a0ac-11e9-9079-e97fad6510fe.png)
